### PR TITLE
Add token configuration, XML comments

### DIFF
--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Controllers/HealthCheckController.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Controllers/HealthCheckController.cs
@@ -6,6 +6,9 @@ namespace MyWellnessPlannerApi.Controllers
     [Route("/healthcheck")]
     public class HealthCheckController : Controller
     {
+        /// <summary>
+        /// Used to ensure the health of the application
+        /// </summary>
         [HttpGet]
         public IActionResult IsHealthy()
         {

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Controllers/LoginController.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Controllers/LoginController.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using MyWellnessPlannerApi.Models;
+using MyWellnessPlannerApi.Services.Interfaces;
+using System;
+using System.Collections.Generic;
 
 namespace MyWellnessPlannerApi.Controllers
 {
@@ -7,10 +10,34 @@ namespace MyWellnessPlannerApi.Controllers
     [Route("/api/login")]
     public class LoginController : Controller
     {
+        private readonly ITokenService _tokenService;
+        public LoginController(ITokenService tokenService)
+        {
+            _tokenService = tokenService;
+        }
+
+        /// <summary>
+        /// Is called on logging in to application, checks if valid credentials are sent
+        /// </summary>
         [HttpPost]
+        [ProducesResponseType(typeof(LoginResponse), 200)]
+        [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
+        [ProducesResponseType(500)]
         public IActionResult Login(LoginRequest request)
         {
-            return Ok();
+            // TODO: Check if user exists in DB
+            try
+            {
+                var response = new LoginResponse
+                {
+                    Token = _tokenService.GenerateToken(request?.UserName)
+                };
+                return Ok(response);
+            }
+            catch(Exception e)
+            {
+                throw e;
+            }
         }
     }
 }

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Models/LoginResponse.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Models/LoginResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace MyWellnessPlannerApi.Models
+{
+    public class LoginResponse
+    {
+        public string Token { get; set; }
+    }
+}

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/MyWellnessPlannerApi.csproj
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/MyWellnessPlannerApi.csproj
@@ -4,8 +4,14 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>C:\Users\kylec\source\repos\my-wellness-planner-api\MyWellnessPlannerApi\MyWellnessPlannerApi\MyWellnessPlannerApi.xml</DocumentationFile>
+    <NoWarn>1701;1702;1591</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
   </ItemGroup>
 
 </Project>

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/MyWellnessPlannerApi.xml
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/MyWellnessPlannerApi.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>MyWellnessPlannerApi</name>
+    </assembly>
+    <members>
+        <member name="M:MyWellnessPlannerApi.Controllers.HealthCheckController.IsHealthy">
+            <summary>
+            Used to ensure the health of the application
+            </summary>
+        </member>
+        <member name="M:MyWellnessPlannerApi.Controllers.LoginController.Login(MyWellnessPlannerApi.Models.LoginRequest)">
+            <summary>
+            Is called on logging in to application, checks if valid credentials are sent
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Options/TokenOptions.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Options/TokenOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace MyWellnessPlannerApi.Options
+{
+    public class TokenOptions
+    {
+        public string Secret { get; set; }
+        public string Isssuer { get; set; }
+        public string Audience { get; set; }
+    }
+}

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Services/Implementations/TokenService.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Services/Implementations/TokenService.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using MyWellnessPlannerApi.Options;
+using MyWellnessPlannerApi.Services.Interfaces;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace MyWellnessPlannerApi.Services.Implementations
+{
+    public class TokenService : ITokenService
+    {
+		private readonly TokenOptions Configuration;
+		
+		public TokenService(IOptions<TokenOptions> configuration)
+        {
+			Configuration = configuration.Value;
+        }
+		public string GenerateToken(string username)
+		{
+			var mySecret = Configuration.Secret;
+			var mySecurityKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(mySecret));
+
+			var myIssuer = Configuration.Isssuer;
+			var myAudience = Configuration.Audience;
+
+			var tokenHandler = new JwtSecurityTokenHandler();
+			var tokenDescriptor = new SecurityTokenDescriptor
+			{
+				Subject = new ClaimsIdentity(new Claim[]
+				{
+					new Claim(ClaimTypes.NameIdentifier, username.ToString()),
+				}),
+				Expires = DateTime.UtcNow.AddDays(1),
+				Issuer = myIssuer,
+				Audience = myAudience,
+				SigningCredentials = new SigningCredentials(mySecurityKey, SecurityAlgorithms.HmacSha256Signature)
+			};
+
+			var token = tokenHandler.CreateToken(tokenDescriptor);
+			return tokenHandler.WriteToken(token);
+		}
+	}
+}

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Services/Interfaces/ITokenService.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Services/Interfaces/ITokenService.cs
@@ -1,0 +1,7 @@
+﻿namespace MyWellnessPlannerApi.Services.Interfaces
+{
+    public interface ITokenService
+    {
+        string GenerateToken(string username);
+    }
+}

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/Startup.cs
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/Startup.cs
@@ -4,7 +4,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
-using System;
+using MyWellnessPlannerApi.Options;
+using MyWellnessPlannerApi.Services.Implementations;
+using MyWellnessPlannerApi.Services.Interfaces;
+using System.IO;
 
 namespace MyWellnessPlannerApi
 {
@@ -20,6 +23,8 @@ namespace MyWellnessPlannerApi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddScoped<ITokenService, TokenService>();
+            services.Configure<TokenOptions>(Configuration.GetSection("TokenOptions"));
             services.AddControllers();
             services.AddSwaggerGen(options =>
             {
@@ -29,6 +34,8 @@ namespace MyWellnessPlannerApi
                     Title = "MyWellnessPlannerApi",
                     Description = "An ASP.NET Core Web API for My Wellness Planner"
                 });
+                var filePath = Path.Combine(System.AppContext.BaseDirectory, "MyWellnessPlannerApi.xml");
+                options.IncludeXmlComments(filePath);
             });
         }
 

--- a/MyWellnessPlannerApi/MyWellnessPlannerApi/appsettings.json
+++ b/MyWellnessPlannerApi/MyWellnessPlannerApi/appsettings.json
@@ -6,5 +6,10 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "TokenOptions": {
+    "Secret": "h86sdg@#gs7g@^@%df98d#@4dagd",
+    "Issuer": "myIssuer",
+    "Audience": "myAudience"
+  }
 }


### PR DESCRIPTION
This PR makes it to where when the user sends a valid request (any email for the username and any string for the password until we implement mongo) to /api/login, a JWT token is returned. The token should be used in all subsequent requests in order to authenticate the user. I also added some XML documentation to the swagger doc. 